### PR TITLE
fix regex for lastMedicationDispense EX

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-EX-LastMedicationDispense.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-EX-LastMedicationDispense.json
@@ -57,7 +57,7 @@
             "key": "workflow-letzteAbgabeDatumsFormat",
             "severity": "error",
             "human": "The 'value' field must match the datetime format up to seconds precision YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)",
-            "expression": "value.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9]|60)?(Z|([+-](0[0-9]|1[0-3]):[0-5][0-9]|14:00))$')",
+            "expression": "value.matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(Z|([+-])((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$')",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_LastMedicationDispense"
           }
         ]

--- a/Resources/input/fsh/extensions/GEM_ERP_EX_LastMedicationDispense.fsh
+++ b/Resources/input/fsh/extensions/GEM_ERP_EX_LastMedicationDispense.fsh
@@ -14,5 +14,5 @@ Description: "This extension should be used in the Task ressource. It shows the 
 
 Invariant:   workflow-letzteAbgabeDatumsFormat
 Description: "The 'value' field must match the datetime format up to seconds precision YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)"
-Expression: "value.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9]|60)?(Z|([+-](0[0-9]|1[0-3]):[0-5][0-9]|14:00))$')"
+Expression: "value.matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(Z|([+-])((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$')"
 Severity: #error


### PR DESCRIPTION
For Sushi and JSON Regex may not include "\\" because they can't be escaped properly