### PR TITLE
correct URL of `GEM_ERP_VS_DocumentType` to `https://gematik.de/fhir/…

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Composition.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Composition.json
@@ -109,7 +109,7 @@
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType"
+          "valueSet": "https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType"
         }
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Task.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Task.json
@@ -256,7 +256,7 @@
         "path": "Task.input.type.coding",
         "binding": {
           "strength": "required",
-          "valueSet": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType"
+          "valueSet": "https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType"
         }
       },
       {
@@ -299,7 +299,7 @@
         "path": "Task.input.type.coding",
         "binding": {
           "strength": "required",
-          "valueSet": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType"
+          "valueSet": "https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType"
         }
       },
       {
@@ -337,7 +337,7 @@
         "path": "Task.input.type.coding",
         "binding": {
           "strength": "required",
-          "valueSet": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType"
+          "valueSet": "https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType"
         }
       },
       {
@@ -392,7 +392,7 @@
         "path": "Task.output.type.coding",
         "binding": {
           "strength": "required",
-          "valueSet": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType"
+          "valueSet": "https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType"
         }
       },
       {

--- a/Resources/fsh-generated/resources/ValueSet-GEM-ERP-VS-DocumentType.json
+++ b/Resources/fsh-generated/resources/ValueSet-GEM-ERP-VS-DocumentType.json
@@ -5,7 +5,7 @@
   "id": "GEM-ERP-VS-DocumentType",
   "title": "ValueSet of Documenttype Codes",
   "description": "Type of document depending on the recipient.",
-  "url": "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType",
+  "url": "https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType",
   "version": "1.3.0",
   "publisher": "gematik GmbH",
   "contact": [

--- a/Resources/input/fsh/valuesets/GEM_ERP_VS_DocumentType.fsh
+++ b/Resources/input/fsh/valuesets/GEM_ERP_VS_DocumentType.fsh
@@ -2,11 +2,7 @@ ValueSet: GEM_ERP_VS_DocumentType
 Id: GEM-ERP-VS-DocumentType
 Title: "ValueSet of Documenttype Codes"
 Description: "Type of document depending on the recipient."
-* ^url = "https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_VS_DocumentType"
-* insert Versioning
-* ^publisher = "gematik GmbH"
-* ^contact.telecom.system = #url
-* ^contact.telecom.value = "http://www.gematik.de"
+* insert ValueSet(GEM_ERP_VS_DocumentType)
 //* ^expansion.identifier = "fe7e0ee0-f72e-4909-bf48-7c84ff97bac5"
 //* ^expansion.timestamp = "2020-05-07T07:48:29+00:00"
 //* ^expansion.total = 3


### PR DESCRIPTION
Hier ein Vorschlag zur Diskussion.

Bei der Einführung der Rulesets ist aufgefallen, dass es eine Unstimmigkeit bei der URL von `GEM_ERP_VS_DocumentType` gibt. 

Nachfolgend sind die Auswirkungen zu sehen, die eine Korrektur der URL auf `https://gematik.de/fhir/erp/ValueSet/GEM_ERP_VS_DocumentType` hätte.

Änderungen gäbe es in der SDs von Composition, Task und DocumentType. Auf die Beispiel-Instanzen und Echtwelt-Instanzen sollte dies meiner Meinung keine Auswirkungen haben, da sich hier auf das CodeSystem bezogen wird.