### PR TITLE
Hinzufügen von Datumsconstraint zu MedicationDispense

### DIFF
--- a/Resources/fsh-generated/resources/MedicationDispense-Example-MedicationDispense.json
+++ b/Resources/fsh-generated/resources/MedicationDispense-Example-MedicationDispense.json
@@ -1,0 +1,109 @@
+{
+  "resourceType": "MedicationDispense",
+  "id": "Example-MedicationDispense",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"
+    ]
+  },
+  "status": "completed",
+  "identifier": [
+    {
+      "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId",
+      "value": "160.000.033.491.280.78"
+    }
+  ],
+  "performer": [
+    {
+      "actor": {
+        "identifier": {
+          "system": "https://gematik.de/fhir/sid/telematik-id",
+          "value": "1-SMC-B-Testkarte-883110000095957"
+        }
+      }
+    }
+  ],
+  "subject": {
+    "identifier": {
+      "system": "http://fhir.de/sid/gkv/kvid-10",
+      "value": "X123456789"
+    }
+  },
+  "whenHandedOver": "2024-04-03",
+  "whenPrepared": "2024-04-03",
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "001413e4-a5e9-48da-9b07-c17bab476407",
+      "meta": {
+        "profile": [
+          "https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0"
+        ]
+      },
+      "extension": [
+        {
+          "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220331",
+                "code": "763158003",
+                "display": "Medicinal product (product)"
+              }
+            ]
+          }
+        },
+        {
+          "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category",
+          "valueCoding": {
+            "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category",
+            "code": "00"
+          }
+        },
+        {
+          "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine",
+          "valueBoolean": false
+        },
+        {
+          "url": "http://fhir.de/StructureDefinition/normgroesse",
+          "valueCode": "N1"
+        }
+      ],
+      "code": {
+        "coding": [
+          {
+            "system": "http://fhir.de/CodeSystem/ifa/pzn",
+            "code": "06313728"
+          }
+        ],
+        "text": "Sumatriptan-1a Pharma 100 mg Tabletten"
+      },
+      "form": {
+        "coding": [
+          {
+            "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
+            "code": "TAB"
+          }
+        ]
+      },
+      "amount": {
+        "numerator": {
+          "unit": "St",
+          "extension": [
+            {
+              "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize",
+              "valueString": "20 St."
+            }
+          ]
+        },
+        "denominator": {
+          "value": 1
+        }
+      }
+    }
+  ],
+  "medicationReference": {
+    "reference": "#001413e4-a5e9-48da-9b07-c17bab476407"
+  }
+}

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
@@ -144,7 +144,7 @@
             "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
             "severity": "error",
-            "expression": "toString().matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$')"
+            "expression": "toString().matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
           }
         ],
         "mustSupport": false
@@ -159,7 +159,7 @@
             "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
             "severity": "error",
-            "expression": "toString().matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$')"
+            "expression": "toString().matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
           }
         ]
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
@@ -144,7 +144,7 @@
             "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
             "severity": "error",
-            "expression": "toString().matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
+            "expression": "toString().length()=10"
           }
         ],
         "mustSupport": false
@@ -159,7 +159,7 @@
             "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
             "severity": "error",
-            "expression": "toString().matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
+            "expression": "toString().length()=10"
           }
         ]
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
@@ -138,12 +138,30 @@
       {
         "id": "MedicationDispense.whenPrepared",
         "path": "MedicationDispense.whenPrepared",
+        "constraint": [
+          {
+            "key": "workflow-abgabeDatumsFormat",
+            "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
+            "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
+            "severity": "error",
+            "expression": "toString().matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$')"
+          }
+        ],
         "mustSupport": false
       },
       {
         "id": "MedicationDispense.whenHandedOver",
         "path": "MedicationDispense.whenHandedOver",
-        "min": 1
+        "min": 1,
+        "constraint": [
+          {
+            "key": "workflow-abgabeDatumsFormat",
+            "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
+            "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
+            "severity": "error",
+            "expression": "toString().matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$')"
+          }
+        ]
       },
       {
         "id": "MedicationDispense.dosageInstruction",

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
@@ -22,5 +22,13 @@ Description: "Handles information about the redeem of the prescription and the s
 * performer.actor.identifier 1..
 * performer.actor.identifier only IdentifierTelematikId
 * whenPrepared ^mustSupport = false
+* whenPrepared obeys workflow-abgabeDatumsFormat
 * whenHandedOver 1..
+* whenHandedOver obeys workflow-abgabeDatumsFormat
 * dosageInstruction MS
+
+Invariant: workflow-abgabeDatumsFormat
+Description: "Wert muss ein Datum in der Form: YYYY-MM-DD sein."
+* severity = #error
+* expression = "toString().matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$')"
+

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
@@ -30,5 +30,88 @@ Description: "Handles information about the redeem of the prescription and the s
 Invariant: workflow-abgabeDatumsFormat
 Description: "Wert muss ein Datum in der Form: YYYY-MM-DD sein."
 * severity = #error
-* expression = "toString().matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$')"
+* expression = "toString().matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
 
+Instance: Example-MedicationDispense
+InstanceOf: GEM_ERP_PR_MedicationDispense
+Usage: #example
+Title: "Example-Medication Dispense"
+Description: "Example of a Medication Dispense."
+* identifier.system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier.value = "160.000.033.491.280.78"
+* subject.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* subject.identifier.value = "X123456789"
+* performer.actor.identifier.system = "https://gematik.de/fhir/sid/telematik-id"
+* performer.actor.identifier.value = "1-SMC-B-Testkarte-883110000095957"
+* whenHandedOver = "2024-04-03"
+* whenPrepared = "2024-04-03"
+* contained[+] = SumatripanMedication
+* medicationReference.reference = "#001413e4-a5e9-48da-9b07-c17bab476407"
+
+/*
+
+Instance: INVALID-DATE-Example-MedicationDispense-1
+InstanceOf: GEM_ERP_PR_MedicationDispense
+Usage: #example
+Title: "Example-Medication Dispense"
+Description: "Example of a Medication Dispense."
+* identifier.system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier.value = "160.000.033.491.280.78"
+* subject.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* subject.identifier.value = "X123456789"
+* performer.actor.identifier.system = "https://gematik.de/fhir/sid/telematik-id"
+* performer.actor.identifier.value = "1-SMC-B-Testkarte-883110000095957"
+* whenHandedOver = "2024"
+* whenPrepared = "2024"
+* contained[+] = SumatripanMedication
+* medicationReference.reference = "#001413e4-a5e9-48da-9b07-c17bab476407"
+
+Instance: INVALID-DATE-Example-MedicationDispense-2
+InstanceOf: GEM_ERP_PR_MedicationDispense
+Usage: #example
+Title: "Example-Medication Dispense"
+Description: "Example of a Medication Dispense."
+* identifier.system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier.value = "160.000.033.491.280.78"
+* subject.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* subject.identifier.value = "X123456789"
+* performer.actor.identifier.system = "https://gematik.de/fhir/sid/telematik-id"
+* performer.actor.identifier.value = "1-SMC-B-Testkarte-883110000095957"
+* whenHandedOver = "2024-04"
+* whenPrepared = "2024-04"
+* contained[+] = SumatripanMedication
+* medicationReference.reference = "#001413e4-a5e9-48da-9b07-c17bab476407"
+
+Instance: INVALID-DATE-Example-MedicationDispense-3
+InstanceOf: GEM_ERP_PR_MedicationDispense
+Usage: #example
+Title: "Example-Medication Dispense"
+Description: "Example of a Medication Dispense."
+* identifier.system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier.value = "160.000.033.491.280.78"
+* subject.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* subject.identifier.value = "X123456789"
+* performer.actor.identifier.system = "https://gematik.de/fhir/sid/telematik-id"
+* performer.actor.identifier.value = "1-SMC-B-Testkarte-883110000095957"
+* whenHandedOver = "2024-04-03T15:28:00+00:00"
+* whenPrepared = "2024-04-03T15:28:00+00:00"
+* contained[+] = SumatripanMedication
+* medicationReference.reference = "#001413e4-a5e9-48da-9b07-c17bab476407"
+
+Instance: INVALID-DATE-Example-MedicationDispense-4
+InstanceOf: GEM_ERP_PR_MedicationDispense
+Usage: #example
+Title: "Example-Medication Dispense"
+Description: "Example of a Medication Dispense."
+* identifier.system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier.value = "160.000.033.491.280.78"
+* subject.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* subject.identifier.value = "X123456789"
+* performer.actor.identifier.system = "https://gematik.de/fhir/sid/telematik-id"
+* performer.actor.identifier.value = "1-SMC-B-Testkarte-883110000095957"
+* whenHandedOver = "2024-04-03T00:00:00.000Z"
+* whenPrepared = "2024-04-03T00:00:00.000Z"
+* contained[+] = SumatripanMedication
+* medicationReference.reference = "#001413e4-a5e9-48da-9b07-c17bab476407"
+
+*/

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
@@ -30,7 +30,7 @@ Description: "Handles information about the redeem of the prescription and the s
 Invariant: workflow-abgabeDatumsFormat
 Description: "Wert muss ein Datum in der Form: YYYY-MM-DD sein."
 * severity = #error
-* expression = "toString().matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$')"
+* expression = "toString().length()=10"
 
 Instance: Example-MedicationDispense
 InstanceOf: GEM_ERP_PR_MedicationDispense


### PR DESCRIPTION
Als Ergänzung zur Veröffentlichung der Workflow Profile sollen die AFOs A_22073 und A_24282 abgelöst und durch einen FHIR-Constraint ersetzt werden.

Dieser PR fügt die Constraints für
MedicationDispense.whenHandedOver und
MedicationDispense.whenPrepared

ein.

Es wurden auch INVALID Beispiele in der fsh File hinzugefügt, die lokal dann getestet werden können.