### PR TITLE
Optionale Angaben im Numerator der Wirkstärke

### DIFF
--- a/Resources/fsh-generated/resources/Medication-DAVNumeratorExample.json
+++ b/Resources/fsh-generated/resources/Medication-DAVNumeratorExample.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "Medication",
+  "id": "DAVNumeratorExample",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Medication|1.4"
+    ]
+  },
+  "ingredient": [
+    {
+      "strength": {
+        "numerator": {
+          "value": 10,
+          "unit": "Stück",
+          "_system": {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          },
+          "_code": {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        }
+      },
+      "itemReference": {
+        "display": "Gematico Medikation"
+      }
+    }
+  ]
+}

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Medication.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Medication.json
@@ -377,8 +377,8 @@
         "mustSupport": true
       },
       {
-        "id": "Medication.ingredient.strength.numerator.extension:dataAbsentReason",
-        "path": "Medication.ingredient.strength.numerator.extension",
+        "id": "Medication.ingredient.strength.numerator.system.extension:dataAbsentReason",
+        "path": "Medication.ingredient.strength.numerator.system.extension",
         "sliceName": "dataAbsentReason",
         "min": 0,
         "max": "1",
@@ -393,13 +393,13 @@
         "mustSupport": true
       },
       {
-        "id": "Medication.ingredient.strength.numerator.extension:dataAbsentReason.value[x]",
-        "path": "Medication.ingredient.strength.numerator.extension.value[x]",
+        "id": "Medication.ingredient.strength.numerator.system.extension:dataAbsentReason.value[x]",
+        "path": "Medication.ingredient.strength.numerator.system.extension.value[x]",
         "patternCode": "unknown"
       },
       {
-        "id": "Medication.ingredient.strength.denominator.extension:dataAbsentReason",
-        "path": "Medication.ingredient.strength.denominator.extension",
+        "id": "Medication.ingredient.strength.numerator.code.extension:dataAbsentReason",
+        "path": "Medication.ingredient.strength.numerator.code.extension",
         "sliceName": "dataAbsentReason",
         "min": 0,
         "max": "1",
@@ -414,8 +414,50 @@
         "mustSupport": true
       },
       {
-        "id": "Medication.ingredient.strength.denominator.extension:dataAbsentReason.value[x]",
-        "path": "Medication.ingredient.strength.denominator.extension.value[x]",
+        "id": "Medication.ingredient.strength.numerator.code.extension:dataAbsentReason.value[x]",
+        "path": "Medication.ingredient.strength.numerator.code.extension.value[x]",
+        "patternCode": "unknown"
+      },
+      {
+        "id": "Medication.ingredient.strength.denominator.system.extension:dataAbsentReason",
+        "path": "Medication.ingredient.strength.denominator.system.extension",
+        "sliceName": "dataAbsentReason",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+            ]
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "Medication.ingredient.strength.denominator.system.extension:dataAbsentReason.value[x]",
+        "path": "Medication.ingredient.strength.denominator.system.extension.value[x]",
+        "patternCode": "unknown"
+      },
+      {
+        "id": "Medication.ingredient.strength.denominator.code.extension:dataAbsentReason",
+        "path": "Medication.ingredient.strength.denominator.code.extension",
+        "sliceName": "dataAbsentReason",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+            ]
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "Medication.ingredient.strength.denominator.code.extension:dataAbsentReason.value[x]",
+        "path": "Medication.ingredient.strength.denominator.code.extension.value[x]",
         "patternCode": "unknown"
       }
     ]

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_Medication.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_Medication.fsh
@@ -55,10 +55,15 @@ Description: "Handles medical information about the redeemed prescription"
 * ingredient.strength.extension[MengeFreitext].valueString MS
 * ingredient.strength.extension[MengeFreitext].valueString ^sliceName = "valueString"
 
-* ingredient.strength.numerator.extension contains $data-absent-reason named dataAbsentReason 0..1 MS
-* ingredient.strength.numerator.extension[dataAbsentReason].value[x] = #unknown
-* ingredient.strength.denominator.extension contains $data-absent-reason named dataAbsentReason 0..1 MS
-* ingredient.strength.denominator.extension[dataAbsentReason].value[x] = #unknown
+* ingredient.strength.numerator.system.extension contains $data-absent-reason named dataAbsentReason 0..1 MS
+* ingredient.strength.numerator.system.extension[dataAbsentReason].value[x] = #unknown
+* ingredient.strength.numerator.code.extension contains $data-absent-reason named dataAbsentReason 0..1 MS
+* ingredient.strength.numerator.code.extension[dataAbsentReason].value[x] = #unknown
+
+* ingredient.strength.denominator.system.extension contains $data-absent-reason named dataAbsentReason 0..1 MS
+* ingredient.strength.denominator.system.extension[dataAbsentReason].value[x] = #unknown
+* ingredient.strength.denominator.code.extension contains $data-absent-reason named dataAbsentReason 0..1 MS
+* ingredient.strength.denominator.code.extension[dataAbsentReason].value[x] = #unknown
 
 // Add amount.numerator Extensions
 * amount.numerator.extension ^slicing.discriminator.type = #value
@@ -106,3 +111,15 @@ Usage: #example
 * amount.numerator.extension[Gesamtmenge].url = "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize"
 * amount.numerator.extension[Gesamtmenge].valueString = "20 St."
 * amount.denominator.value = 1
+
+
+Instance: DAVNumeratorExample
+InstanceOf: GEM_ERP_PR_Medication
+Title:   "DAV Example"
+Usage: #example
+* ingredient.itemReference.display = "Gematico Medikation"
+* ingredient.strength.numerator.value = 10
+* ingredient.strength.numerator.unit = "Stück"
+* ingredient.strength.numerator
+* ingredient.strength.numerator.system.extension[dataAbsentReason].valueCode = #unknown
+* ingredient.strength.numerator.code.extension[dataAbsentReason].valueCode = #unknown


### PR DESCRIPTION
Für die Version 1.4 der Workflow Profile werden die Profile der Medication und MedicationDispense von den Profilen der ePA abgeleitet.
In Medication.ingredient.strength.numerator sind .code und .system mit der Kardinalität 1..1 belegt.

Diese können die AVS aktuell im Kontext E-Rezept nicht immer liefern, wesewegen eine data-absent-reason Extension an dieser Stelle eingebaut wurde.