### PR TITLE
Add example for MedicationDispense without Medication

### DIFF
--- a/Resources/fsh-generated/resources/MedicationDispense-Example-MedicationDispense-Without-Medication.json
+++ b/Resources/fsh-generated/resources/MedicationDispense-Example-MedicationDispense-Without-Medication.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "MedicationDispense",
+  "id": "Example-MedicationDispense-Without-Medication",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.4"
+    ]
+  },
+  "identifier": [
+    {
+      "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId",
+      "value": "160.000.033.491.280.78"
+    }
+  ],
+  "status": "completed",
+  "subject": {
+    "identifier": {
+      "system": "http://fhir.de/sid/gkv/kvid-10",
+      "value": "X123456789"
+    }
+  },
+  "performer": [
+    {
+      "actor": {
+        "identifier": {
+          "system": "https://gematik.de/fhir/sid/telematik-id",
+          "value": "3-SMC-B-Testkarte-883110000095957"
+        }
+      }
+    }
+  ],
+  "medicationReference": {
+    "extension": [
+      {
+        "valueCode": "unsupported",
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+      }
+    ]
+  },
+  "whenHandedOver": "2024-04-03",
+  "whenPrepared": "2024-04-03"
+}

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
@@ -47,6 +47,21 @@ Description: "Example of a Medication Dispense."
 * contained[+] = SumatripanMedication
 * medicationReference.reference = "#001413e4-a5e9-48da-9b07-c17bab476407"
 
+Instance: Example-MedicationDispense-Without-Medication
+InstanceOf: GEM_ERP_PR_MedicationDispense
+Usage: #example
+Title: "Example-Medication Dispense without Medication"
+Description: "Example of a Medication Dispense which does not contain a medication. This is a valid case when the pharmacy is not substituting the medication that was prescribed."
+* identifier[prescriptionID].system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
+* identifier[prescriptionID].value = "160.000.033.491.280.78"
+* subject.identifier.system = "http://fhir.de/sid/gkv/kvid-10"
+* subject.identifier.value = "X123456789"
+* performer.actor.identifier.system = "https://gematik.de/fhir/sid/telematik-id"
+* performer.actor.identifier.value = "3-SMC-B-Testkarte-883110000095957"
+* whenHandedOver = "2024-04-03"
+* whenPrepared = "2024-04-03"
+* medicationReference.extension[dataAbsentReason].valueCode = #unsupported
+
 Instance: Example-DiGA-MedicationDispense
 InstanceOf: GEM_ERP_PR_MedicationDispense
 Usage: #example
@@ -61,6 +76,8 @@ Description: "Example of a Medication Dispense."
 * whenHandedOver = "2024-04-03"
 * whenPrepared = "2024-04-03"
 * medicationReference.display = "Beispiel App für Diabetestherapie"
+
+
 
 /*
 


### PR DESCRIPTION
The current specification offers the option to also submit a MedicationDispense without a Medication in case the medication was not substituted.
This PR offers an example of how to do that.