### PR TITLE
Add constraint for whenprepared

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense.json
@@ -90,6 +90,15 @@
       {
         "id": "MedicationDispense.whenPrepared",
         "path": "MedicationDispense.whenPrepared",
+        "constraint": [
+          {
+            "key": "workflow-abgabeDatumsFormat",
+            "human": "Wert muss ein Datum in der Form: YYYY-MM-DD sein.",
+            "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense",
+            "severity": "error",
+            "expression": "toString().length()=10"
+          }
+        ],
         "mustSupport": false
       },
       {

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense.fsh
@@ -21,6 +21,7 @@ Description: "Handles information about the redeem of the prescription and the s
 * performer.actor.identifier 1..
 * performer.actor.identifier only IdentifierTelematikId
 * whenPrepared ^mustSupport = false
+* whenPrepared obeys workflow-abgabeDatumsFormat
 * whenHandedOver 1..
 * whenHandedOver obeys workflow-abgabeDatumsFormat
 * dosageInstruction MS


### PR DESCRIPTION
Aktuell ist nur das Feld "whenHandedOver" mit einem Constraint belegt, der eine Datumsangabe ohne Zeit fordert. Da es zu Validierungsfehlern kommen kann, wenn bei whenPrepared die Zeit mit angegeben wird, wird dieses hier auch beschränkt.

s. [ANFERP-2555](https://service.gematik.de/browse/ANFERP-2555)