### PR TITLE
Entfernen des Constraint für lastMedicationDispense

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-EX-LastMedicationDispense.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-EX-LastMedicationDispense.json
@@ -32,7 +32,7 @@
       {
         "id": "Extension",
         "path": "Extension",
-        "short": "Timestamp which is set when a medication for this task has been dispensed. Must be stated in the format YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)",
+        "short": "Timestamp which is set when a medication for this task has been dispensed. Stated in the format YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)",
         "definition": "This field allows the E-Rezept-FdV to display to the user that a medication has been dispensed before it was closed by the pharmacy."
       },
       {
@@ -48,18 +48,11 @@
       {
         "id": "Extension.value[x]",
         "path": "Extension.value[x]",
+        "short": "Timestamp which is set when a medication for this task has been dispensed.",
+        "comment": "Stated in the format YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)",
         "type": [
           {
             "code": "instant"
-          }
-        ],
-        "constraint": [
-          {
-            "key": "workflow-letzteAbgabeDatumsFormat",
-            "severity": "error",
-            "human": "The 'value' field must match the datetime format up to seconds precision YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)",
-            "expression": "value.matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(Z|([+-])((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$')",
-            "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_LastMedicationDispense"
           }
         ]
       }

--- a/Resources/input/fsh/extensions/GEM_ERP_EX_LastMedicationDispense.fsh
+++ b/Resources/input/fsh/extensions/GEM_ERP_EX_LastMedicationDispense.fsh
@@ -3,14 +3,11 @@ Id: GEM-ERP-EX-LastMedicationDispense
 Title: "Last Medication Dispense"
 Description: "This extension should be used in the Task ressource. It shows the timestamp of the last dispense."
 * insert StructureDefinition(GEM_ERP_EX_LastMedicationDispense)
-* . ^short = "Timestamp which is set when a medication for this task has been dispensed. Must be stated in the format YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)"
+* . ^short = "Timestamp which is set when a medication for this task has been dispensed. Stated in the format YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)"
 * . ^definition = "This field allows the E-Rezept-FdV to display to the user that a medication has been dispensed before it was closed by the pharmacy."
 * ^context.type = #element
 * ^context.expression = "Task"
 * value[x] only instant
-* value[x] obeys workflow-letzteAbgabeDatumsFormat
+  * ^short = "Timestamp which is set when a medication for this task has been dispensed."
+  * ^comment = "Stated in the format YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)"
 
-Invariant:   workflow-letzteAbgabeDatumsFormat
-Description: "The 'value' field must match the datetime format up to seconds precision YYYY-MM-DDTHH:MM:SS(Z|±HH:MM)"
-Expression: "value.matches('^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(Z|([+-])((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$')"
-Severity: #error


### PR DESCRIPTION
Der Zeitstempel, wann eine Medikation das letzte mal dispensiert wurde, wird vom E-Rezept-Fachdienst gesetzt. Daher muss dieser nie validieren, ob der Wert korrekt gesetzt ist.

Daher wird der Constraint entfernt und mit einem Hinweis für Entwickler versehen, der das Format beschreibt.