### PR TITLE
DiGA-Constraint BugFix for .NET Validator

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Communication-DispReq.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-Communication-DispReq.json
@@ -25,7 +25,7 @@
             "human": "Payload muss angegeben werden, wenn eine Zuweisung für ein Arzneimittel vorgenommen wird",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq",
             "severity": "error",
-            "expression": "(extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').valueCoding.code = '162' implies payload.exists().not()) and (extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').valueCoding.code != '162' implies payload.exists() and payload.empty().not())"
+            "expression": "(extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').value.code = '162' implies payload.exists().not()) and (extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').value.code != '162' implies payload.exists() and payload.empty().not())"
           }
         ]
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense-DiGA.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-GEM-ERP-PR-MedicationDispense-DiGA.json
@@ -31,14 +31,14 @@
             "key": "workflow-medicationdispense-redeemcode-2",
             "severity": "error",
             "human": "The data absent reason was not found, but is mandatory if no redeem code is provided.",
-            "expression": "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').empty() implies medicationReference.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
+            "expression": "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').empty() implies medication.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense_DiGA"
           },
           {
             "key": "workflow-medicationdispense-redeemcode-3",
             "severity": "error",
             "human": "Name and identifier of the DiGA was not found, but is mandatory if a redeem code is provided.",
-            "expression": "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').exists() implies (medicationReference.display.exists() and medicationReference.identifier.exists())",
+            "expression": "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').exists() implies (medication.display.exists() and medication.identifier.exists())",
             "source": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense_DiGA"
           }
         ]

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_Communication_DispReq.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_Communication_DispReq.fsh
@@ -42,4 +42,4 @@ Description: "Ressource used for the communication of dispense request between p
 Invariant: workflow-communication-payload-1
 Description: "Payload muss angegeben werden, wenn eine Zuweisung für ein Arzneimittel vorgenommen wird"
 * severity = #error
-* expression = "(extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').valueCoding.code = '162' implies payload.exists().not()) and (extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').valueCoding.code != '162' implies payload.exists() and payload.empty().not())"
+* expression = "(extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').value.code = '162' implies payload.exists().not()) and (extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType').value.code != '162' implies payload.exists() and payload.empty().not())"

--- a/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense_DiGA.fsh
+++ b/Resources/input/fsh/profiles/GEM_ERP_PR_MedicationDispense_DiGA.fsh
@@ -63,10 +63,10 @@ Severity: #error
 
 Invariant: workflow-medicationdispense-redeemcode-2
 Description: "The data absent reason was not found, but is mandatory if no redeem code is provided."
-Expression: "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').empty() implies medicationReference.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"
+Expression: "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').empty() implies medication.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"
 Severity: #error
 
 Invariant: workflow-medicationdispense-redeemcode-3
 Description: "Name and identifier of the DiGA was not found, but is mandatory if a redeem code is provided."
-Expression: "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').exists() implies (medicationReference.display.exists() and medicationReference.identifier.exists())"
+Expression: "extension.where(url = 'https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_RedeemCode').exists() implies (medication.display.exists() and medication.identifier.exists())"
 Severity: #error


### PR DESCRIPTION
This PR resolves an Issue for the .NET validator which does not resolve `medicationReference` to a field, but must be named `medication`

Also for Communication `valueCoding` was changed to `value`