### PR TITLE
Fix examples totalQuantity Extension

### DIFF
--- a/Resources/fsh-generated/resources/Communication-8ca3c379-ac86-470f-bc12-178c9008f5c9.json
+++ b/Resources/fsh-generated/resources/Communication-8ca3c379-ac86-470f-bc12-178c9008f5c9.json
@@ -123,7 +123,7 @@
           "extension": [
             {
               "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-              "valueString": "20 St."
+              "valueString": "20"
             }
           ],
           "value": 20,

--- a/Resources/fsh-generated/resources/Medication-Medication-Rezeptur-FD.json
+++ b/Resources/fsh-generated/resources/Medication-Medication-Rezeptur-FD.json
@@ -41,7 +41,7 @@
       "extension": [
         {
           "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-          "valueString": "100 ml"
+          "valueString": "100"
         }
       ],
       "value": 20,

--- a/Resources/fsh-generated/resources/Medication-Medication-Rezeptur.json
+++ b/Resources/fsh-generated/resources/Medication-Medication-Rezeptur.json
@@ -41,7 +41,7 @@
       "extension": [
         {
           "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-          "valueString": "100 ml"
+          "valueString": "100"
         }
       ],
       "value": 20,

--- a/Resources/fsh-generated/resources/Medication-SumatripanMedication.json
+++ b/Resources/fsh-generated/resources/Medication-SumatripanMedication.json
@@ -45,7 +45,7 @@
       "extension": [
         {
           "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-          "valueString": "20 St."
+          "valueString": "20"
         }
       ],
       "value": 20,

--- a/Resources/fsh-generated/resources/Parameters-ExampleCloseInputParameters.json
+++ b/Resources/fsh-generated/resources/Parameters-ExampleCloseInputParameters.json
@@ -98,7 +98,7 @@
                 "extension": [
                   {
                     "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-                    "valueString": "20 St."
+                    "valueString": "20"
                   }
                 ],
                 "value": 20,

--- a/Resources/fsh-generated/resources/Parameters-ExampleCloseInputParametersMultipleMedicationDispenses.json
+++ b/Resources/fsh-generated/resources/Parameters-ExampleCloseInputParametersMultipleMedicationDispenses.json
@@ -98,7 +98,7 @@
                 "extension": [
                   {
                     "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-                    "valueString": "20 St."
+                    "valueString": "20"
                   }
                 ],
                 "value": 20,

--- a/Resources/fsh-generated/resources/Parameters-ExampleCloseInputParametersRezeptur.json
+++ b/Resources/fsh-generated/resources/Parameters-ExampleCloseInputParametersRezeptur.json
@@ -94,7 +94,7 @@
                 "extension": [
                   {
                     "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-                    "valueString": "100 ml"
+                    "valueString": "100"
                   }
                 ],
                 "value": 20,

--- a/Resources/fsh-generated/resources/Parameters-ExampleDispenseInputParameters.json
+++ b/Resources/fsh-generated/resources/Parameters-ExampleDispenseInputParameters.json
@@ -98,7 +98,7 @@
                 "extension": [
                   {
                     "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-                    "valueString": "20 St."
+                    "valueString": "20"
                   }
                 ],
                 "value": 20,

--- a/Resources/fsh-generated/resources/Parameters-ExampleDispenseInputParametersMultipleMedicationDispenses.json
+++ b/Resources/fsh-generated/resources/Parameters-ExampleDispenseInputParametersMultipleMedicationDispenses.json
@@ -98,7 +98,7 @@
                 "extension": [
                   {
                     "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-                    "valueString": "20 St."
+                    "valueString": "20"
                   }
                 ],
                 "value": 20,

--- a/Resources/fsh-generated/resources/Parameters-ExampleDispenseOutputParametersSuccess.json
+++ b/Resources/fsh-generated/resources/Parameters-ExampleDispenseOutputParametersSuccess.json
@@ -98,7 +98,7 @@
                 "extension": [
                   {
                     "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension",
-                    "valueString": "20 St."
+                    "valueString": "20"
                   }
                 ],
                 "value": 20,

--- a/Resources/input/fsh/examples/Example_Medication.fsh
+++ b/Resources/input/fsh/examples/Example_Medication.fsh
@@ -19,7 +19,7 @@ Usage: #example
 * form.coding[kbvDarreichungsform].code = #TAB
 * amount.numerator.value = 20
 * amount.numerator.unit = "St"
-* amount.numerator.extension[totalQuantity].valueString = "20 St."
+* amount.numerator.extension[totalQuantity].valueString = "20"
 * amount.denominator.value = 1
 
 Instance: SimpleMedication

--- a/Resources/input/fsh/examples/Example_Medication_Rezeptur.fsh
+++ b/Resources/input/fsh/examples/Example_Medication_Rezeptur.fsh
@@ -21,7 +21,7 @@ Usage: #example
 * form.coding[kbvDarreichungsform].code = #SAL
 * amount.numerator.value = 20
 * amount.numerator.unit = "ml"
-* amount.numerator.extension[totalQuantity].valueString = "100 ml"
+* amount.numerator.extension[totalQuantity].valueString = "100"
 * amount.denominator.value = 1
 * ingredient[+].itemReference = Reference(MedicationHydrocortison)
 * ingredient[=].isActive = true

--- a/Resources/input/fsh/examples/Example_Medication_Rezeptur_FD.fsh
+++ b/Resources/input/fsh/examples/Example_Medication_Rezeptur_FD.fsh
@@ -16,7 +16,7 @@ Usage: #example
 
 * code.text = "Hydrocortison-Dexpanthenol-Salbe"
 * form.text = "Salbe"
-* amount.numerator.extension[totalQuantity].valueString = "100 ml"
+* amount.numerator.extension[totalQuantity].valueString = "100"
 * amount.numerator.value = 20
 * amount.numerator.unit = "ml"
 * amount.denominator.value = 1


### PR DESCRIPTION
According to the definition of https://gematik.de/fhir/epa-medication/StructureDefinition/medication-total-quantity-formulation-extension the unit is not allowed in the value.

This PR fixes the issue