### PR TITLE
Add .dependencyLicenses file to ignore specific files

### DIFF
--- a/.dependencyLicenses
+++ b/.dependencyLicenses
@@ -1,0 +1,1 @@
+./input/content/assets/js/heading-links.js


### PR DESCRIPTION
Introduce a .dependencyLicenses file to specify files that should be ignored in dependency checks.